### PR TITLE
Missing break when applying fonts

### DIFF
--- a/app/src/main/java/es/craftsmanship/toledo/katangapp/utils/KatangaFont.java
+++ b/app/src/main/java/es/craftsmanship/toledo/katangapp/utils/KatangaFont.java
@@ -1,31 +1,32 @@
 package es.craftsmanship.toledo.katangapp.utils;
 
 import android.content.res.AssetManager;
-
 import android.graphics.Typeface;
+import android.support.annotation.NonNull;
 
 /**
  * @author Manuel de la Peña
  */
 public enum KatangaFont {
 
-   QUICKSAND_BOLD, QUICKSAND_LIGHT, QUICKSAND_REGULAR;
+    QUICKSAND_BOLD, QUICKSAND_LIGHT, QUICKSAND_REGULAR;
 
     public static Typeface getFont(AssetManager assetManager, KatangaFont font) {
-        String fontPath = "fonts/Quicksand-Regular.ttf";
-
+        String fontPath = getFontPath(font);
+        return Typeface.createFromAsset(assetManager, fontPath);
+    }
+    
+    @NonNull
+    private static String getFontPath(KatangaFont font) {
         switch (font) {
             case QUICKSAND_BOLD:
-                fontPath = "fonts/Quicksand-Bold.ttf";
-                break;
+                return "fonts/Quicksand-Bold.ttf";
             case QUICKSAND_LIGHT:
-                fontPath = "fonts/Quicksand-Light.ttf";
-                break;
+                return "fonts/Quicksand-Light.ttf";
             case QUICKSAND_REGULAR:
-                fontPath = "fonts/Quicksand-Regular.ttf";
+            default:
+                return "fonts/Quicksand-Regular.ttf";
         }
-
-        return Typeface.createFromAsset(assetManager, fontPath);
     }
 
 }

--- a/app/src/main/java/es/craftsmanship/toledo/katangapp/utils/KatangaFont.java
+++ b/app/src/main/java/es/craftsmanship/toledo/katangapp/utils/KatangaFont.java
@@ -17,8 +17,10 @@ public enum KatangaFont {
         switch (font) {
             case QUICKSAND_BOLD:
                 fontPath = "fonts/Quicksand-Bold.ttf";
+                break;
             case QUICKSAND_LIGHT:
                 fontPath = "fonts/Quicksand-Light.ttf";
+                break;
             case QUICKSAND_REGULAR:
                 fontPath = "fonts/Quicksand-Regular.ttf";
         }


### PR DESCRIPTION
First commit adds breaks and second one uses a switch with default (I don't know if your style guide allows multiple returns).

Are you going to use this fonts a lot in your app? if you plan on using several fields the recommended way of doing it is using a factory that 'caches' the fonts. And also a custom textview to not have to set the font manually from java code. I can send a pull with the changes :)
