### PR TITLE
Using otto to solve orientation problem

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     compile 'com.squareup.retrofit2:retrofit:2.0.0-beta4'
     compile 'com.squareup.retrofit2:converter-jackson:2.0.0-beta4'
 
+    compile 'com.squareup:otto:1.3.8'
+
     testCompile 'junit:junit:4.12'
 
     androidTestCompile 'junit:junit:4.12'

--- a/app/src/main/java/es/craftsmanship/toledo/katangapp/interactors/StopsInteractor.java
+++ b/app/src/main/java/es/craftsmanship/toledo/katangapp/interactors/StopsInteractor.java
@@ -1,0 +1,50 @@
+package es.craftsmanship.toledo.katangapp.interactors;
+
+import java.io.IOException;
+
+import es.craftsmanship.toledo.katangapp.models.QueryResult;
+import es.craftsmanship.toledo.katangapp.services.StopsService;
+import es.craftsmanship.toledo.katangapp.utils.AndroidBus;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+
+/**
+ * @author Javier Gamarra
+ */
+public class StopsInteractor implements Runnable {
+
+    private static final String BACKEND_ENDPOINT = "https://secret-depths-4660.herokuapp.com";
+    private final String radio;
+    private final Double latitude;
+    private final Double longitude;
+
+    public StopsInteractor(String radio, Double latitude, Double longitude) {
+        this.radio = radio;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    @Override
+    public void run() {
+        try {
+            Retrofit retrofit = new Retrofit.Builder()
+                    .baseUrl(BACKEND_ENDPOINT)
+                    .addConverterFactory(JacksonConverterFactory.create())
+                    .build();
+
+            StopsService service = retrofit.create(StopsService.class);
+
+            Response<QueryResult> response = service.listStops(latitude, longitude, radio).execute();
+
+            if (response.isSuccess()) {
+                AndroidBus.getInstance().post(response.body());
+            } else {
+                AndroidBus.getInstance().post(new Error(response.message()));
+            }
+
+        } catch (IOException e) {
+            AndroidBus.getInstance().post(e);
+        }
+    }
+}

--- a/app/src/main/java/es/craftsmanship/toledo/katangapp/utils/AndroidBus.java
+++ b/app/src/main/java/es/craftsmanship/toledo/katangapp/utils/AndroidBus.java
@@ -1,0 +1,39 @@
+package es.craftsmanship.toledo.katangapp.utils;
+
+import android.os.Handler;
+import android.os.Looper;
+
+import com.squareup.otto.Bus;
+
+/**
+ * @author Javier Gamarra
+ */
+public class AndroidBus {
+
+    private static final Bus BUS = new MainThreadBus();
+
+    private AndroidBus() {
+    }
+
+    public static Bus getInstance() {
+        return BUS;
+    }
+
+    public static class MainThreadBus extends Bus {
+        private final Handler handler = new Handler(Looper.getMainLooper());
+
+        @Override
+        public void post(final Object event) {
+            if (Looper.myLooper() == Looper.getMainLooper()) {
+                super.post(event);
+            } else {
+                handler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        MainThreadBus.super.post(event);
+                    }
+                });
+            }
+        }
+    }
+}


### PR DESCRIPTION
Recreated to refactor some code

This is a hard-to-explain pull request.

The current code (and the previous async task code) has a bug/problem with orientation changes. When the screen rotates, the activity gets destroyed, creating leaks, bugs...

With this PR these problems are fixed because when the thread finishes, either someone is listening to the event (the activity or the new activity are alive) and receives the event or noone listens.

This solution could be improved (in a later PR) sending tasks in an executor (instead a thread) and wrapping the runnable to allow passing parameters.

Although otto is deprecated (eventbus also has problems), the trendy alternative, RxJava, is hard to explain in a PR :P
